### PR TITLE
Added mapping for London region

### DIFF
--- a/01-configuring-your-aws-account/LabMachine.json
+++ b/01-configuring-your-aws-account/LabMachine.json
@@ -16,6 +16,9 @@
           "eu-west-1": {
                 "AMI": "ami-f9dd458a"
             },
+          "eu-west-2": {
+                "AMI": "ami-f1949e95"
+            },
           "eu-central-1": {
                 "AMI": "ami-ea26ce85"
             },


### PR DESCRIPTION
Added a mapping to "AWSRegionToAMI" in LabMachine CloudFormation template to allow creation of EC2 instance in the London region.