### PR TITLE
Fix curly quote issues in file PUT-ITEM-SYNTAX.txt. 

### DIFF
--- a/03-working-with-items/PUT-ITEM-SYNTAX.txt
+++ b/03-working-with-items/PUT-ITEM-SYNTAX.txt
@@ -1,7 +1,7 @@
 ITEM SYNTAX
 
 {
-    "AttributeName": {"TYPE": "AttributeValue”},
+    "AttributeName": {"TYPE": "AttributeValue"},
     "AttributeName": {"TYPE": [LIST},
     "AttributeName": {"TYPE": {"map" : "key"}
 }
@@ -16,4 +16,4 @@ POPULATED
 
 FLATTENED FOR CLI USE
 
-{"station_id”: {"S": “000001”},"dateandtime": {"S": “2015/12/25 00:00"},"temperature": {"N": "0"}}
+{"station_id”: {"S": "000001"},"dateandtime": {"S": "2015/12/25 00:00"},"temperature": {"N": "0"}}


### PR DESCRIPTION
Copying and pasting the current code with curly quotes causes errors with aws cli.